### PR TITLE
Fix empty android pool exception

### DIFF
--- a/lib/Entity/Android.php
+++ b/lib/Entity/Android.php
@@ -62,7 +62,7 @@ class Android extends Base
         if ($emailAddress == '') {
             return $data;
         } else {
-            if (count($data) < 0) {
+            if (count($data) <= 0) {
                 throw new NotFoundException('Email Address ' . $emailAddress . ' not found', 'android');
             }
 


### PR DESCRIPTION
Currently the code is not throwing an exception when a license pool is empty or not found.